### PR TITLE
change line endings to Windows style, and update install.cmd

### DIFF
--- a/install.cmd
+++ b/install.cmd
@@ -26,11 +26,11 @@ echo     1. Right-click on it while pressing "Shift".
 echo     2. Click on "Copy as Path".
 echo     3. Right-click in this command prompt.
 echo     4. If the path has not pasted itself already, click on "Paste".
-echo     5. Remove the quotes at the beginning and the end.
-echo     6. Press "Enter" to validate.
+echo     5. Press "Enter" to validate.
 echo.
 echo.
-set /P Executable=Move the executable at any desired permanent location, and then type it's location here without quotes:
+set /P Executablewq=Move the executable at any desired permanent location, and then type its location here: 
+call:GetFilenameWithoutQuotes %Executablewq%
 IF NOT DEFINED Executable (
     cls
     echo You did not specify a file!
@@ -50,3 +50,8 @@ echo A dialog will show after you press any key. Select "SearchWithMyBrowser.exe
 pause
 rundll32.exe shell32.dll,OpenAs_RunDLL microsoft-edge:
 :End
+:GetFilenameWithoutQuotes
+if not [%2]==[] set noquotes=1
+if [%noquotes%]==[1] (set Executable=%* & exit /b)
+set Executable=%~f1
+exit /b


### PR DESCRIPTION
I think that for Windows software one should really use Windows-style line endings, since Notepad in Windows Vista and up, including the latest Notepad bundled with the latest Windows 10 _no longer supports Unix style line endings_. I don't know why they don't, but they don't, and this means that you cannot edit these files with software included in a stock Windows 10 installation.

So I changed the line endings for all the files to Windows-style. I think. I'm not used to Notepad++, so I might have missed one or something.

Also, install.cmd previously required there to be no quotes around the supplied executable, which meant that the instructions presented in the window required you to remove quotes. Now install.cmd doesn't mind quotes being there. That is, you can simply copy the path to SearchWithMyBrowser.exe as Windows provides (with quotes), paste it in the CMD window, and press enter.

I did this sloppily and in minutes because when I saw this it bugged me. I'd like to clean it up a bit more, and make installation even simpler later on (i.e., have install.cmd run make.cmd if necessary -- and not require entering the path to SearchWithMyBrowser.exe at all, copy SearchWithMyBrowser.exe somewhere safe and predictable (we already have administrative privileges, why not actually _install_ it?!)
